### PR TITLE
turn off source maps for ng test

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -20,8 +20,15 @@ module.exports = function (config) {
       fixWebpackSourcePaths: true
     },
     angularCli: {
-      environment: 'dev'
-    },
+      environment: 'dev',
+      sourcemaps: false,
+      COMMENT_on_sourcemaps: [
+        'as described in issue https://github.com/angular/angular-cli/issues/7296',
+        'source maps have to be turned off for ng cli in face of karma tests',
+        'for legible error messages in some cases (e.g. html template access missing function)',
+        'this configuration however is only used when running `karma start`'
+      ]
+   },
     reporters: ['progress', 'kjhtml'],
     port: 9876,
     colors: true,

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "ng": "ng",
     "start": "ng serve",
     "build": "ng build --prod",
-    "test": "ng test",
+    "test": "ng test -sm=false",
     "test:once": "ng test --single-run",
     "lint": "ng lint",
     "pree2e": "webdriver-manager update --ignore_ssl",

--- a/package.json
+++ b/package.json
@@ -7,12 +7,17 @@
     "start": "ng serve",
     "build": "ng build --prod",
     "test": "ng test -sm=false",
-    "test:once": "ng test --single-run",
+    "test:once": "ng test -sm=false --single-run",
     "lint": "ng lint",
     "pree2e": "webdriver-manager update --ignore_ssl",
     "e2e": "ng e2e -wu false",
     "packagr": "ng-packagr -p ng-package.json"
   },
+  "COMMENT_scripts_test": [
+    "as described in issue https://github.com/angular/angular-cli/issues/7296",
+    "source maps have to be turned off for ng cli (-sm=false)",
+    "for legible error messages in some cases (e.g. html template access missing function)"
+  ],
   "private": true,
   "peerDependencies": {
     "@angular/core": "^5.2.0",


### PR DESCRIPTION
There's a bug preventing the actual error message to be shown when executing tests - this is the workaround.
See: https://github.com/angular/angular-cli/issues/7296